### PR TITLE
Added .pdf in the output name as default to avoid incompatible extension

### DIFF
--- a/PdfScribe/Program_2.cs
+++ b/PdfScribe/Program_2.cs
@@ -37,7 +37,7 @@ namespace PdfScribe
                             {
                                 // Replace illegal characters with spaces
                                 Regex regEx = new Regex(@"[\\/:""*?<>|]");
-                                pdfFilenameDialog.FileName = regEx.Replace(Environment.GetEnvironmentVariable("REDMON_DOCNAME"), " ");
+                                pdfFilenameDialog.FileName = regEx.Replace(Environment.GetEnvironmentVariable("REDMON_DOCNAME"), " ") + ".pdf";
                             }
                             if (pdfFilenameDialog.ShowDialog(dialogOwner) == DialogResult.OK)
                             {


### PR DESCRIPTION
I have tried you PdfScribe and everything went smooth until I had the same problem that is stated in one of your open issue (https://github.com/stchan/PdfScribe/issues/49).

In order to solve this problem, I have added '.pdf' by default at the end of the output filename in order to avoid incompatible generated pdf files due to the wrong extension.

![image](https://github.com/stchan/PdfScribe/assets/9128612/28527405-f9bf-4c60-a901-24bb6d139524)
